### PR TITLE
Имена в markdown

### DIFF
--- a/src/handlers/admin/callbacks.py
+++ b/src/handlers/admin/callbacks.py
@@ -8,8 +8,11 @@ from aiogram import (
 from config import Config
 from states import AdminPanel
 from database.methods import User
-from methods.messages import text_replace
 from handlers.admin.messages import send_panel_message
+from methods.messages import (
+    text_replace,
+    md_replace_text
+)
 from keyboard import (
     create_markup,
     create_button
@@ -83,7 +86,7 @@ async def delete_answer_callback_handler(callback: CallbackQuery) -> None:
     await callback.message.edit_text(
         text_replace(
             Config.TEXTS["admin"]["panel"]["user_answer_deleted"],
-            full_name=f"{user.first_name} {user.last_name}"
+            full_name=md_replace_text(f"{user.first_name} {user.last_name}")
         )
     )
 

--- a/src/handlers/questions/messages.py
+++ b/src/handlers/questions/messages.py
@@ -122,7 +122,7 @@ async def messages_handler(message: Message, state: FSMContext) -> None:
                     admin,
                     text_replace(
                         Config.TEXTS["admin"]["panel"]["questions_report"],
-                        full_name=message.chat.full_name,
+                        full_name=md_replace_text(message.chat.full_name),
                         report_text="\n".join(report_text)
                     ),
                     reply_markup=create_markup(


### PR DESCRIPTION
## Изменения
- В некоторых текстах теперь исправлены имена. Они изменяются с ```md_replace_text```